### PR TITLE
Refactor operation module

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -79,7 +79,12 @@ impl fmt::Display for Error<'_> {
     write!(
       f,
       "Error on line {}, column {}: {}\n  {}\n  {}{}",
-      token.line_number, token.column_number, token.value, token.line.trim_end(), padding, pointer
+      token.line_number,
+      token.column_number,
+      token.value,
+      token.line.trim_end(),
+      padding,
+      pointer
     )
   }
 }

--- a/src/parser/constants.rs
+++ b/src/parser/constants.rs
@@ -1,9 +1,10 @@
 use crate::lexer::*;
+use crate::operation;
 
-pub const KEYWORD_ADD: TokenValue = Word("Add");
-pub const KEYWORD_CREATE: TokenValue = Word("Create");
-pub const KEYWORD_REMOVE: TokenValue = Word("Remove");
-pub const KEYWORD_SHOW: TokenValue = Word("Show");
+pub const KEYWORD_ADD: TokenValue = Word(operation::OperationAdd::keyword());
+pub const KEYWORD_CREATE: TokenValue = Word(operation::OperationCreate::keyword());
+pub const KEYWORD_REMOVE: TokenValue = Word(operation::OperationRemove::keyword());
+pub const KEYWORD_SHOW: TokenValue = Word(operation::OperationShow::keyword());
 pub const KEYWORDS: [TokenValue; 4] = [KEYWORD_ADD, KEYWORD_CREATE, KEYWORD_REMOVE, KEYWORD_SHOW];
 
 pub const LINKER_AND: TokenValue = Word("and");

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -46,7 +46,12 @@ fn fmt_unexpected(e: &Error) -> String {
           "\n{} on line {}, column {}:
   {}
   {}{}",
-          s, un_token.line_number, un_token.column_number, un_token.line.trim_end(), padding, pointer
+          s,
+          un_token.line_number,
+          un_token.column_number,
+          un_token.line.trim_end(),
+          padding,
+          pointer
         )
       } else {
         let offset = un_token.column_number

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -1,5 +1,4 @@
 use super::lexer;
-use crate::operation;
 use crate::util;
 use std::borrow::Cow;
 use std::error;
@@ -7,7 +6,7 @@ use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Error<'a> {
-  operation_kind: operation::OperationKind,
+  operation_keyword: &'static str,
   operation_token: lexer::Token<'a>,
   unexpected_token: Option<lexer::Token<'a>>,
   expected_tokens: Option<Cow<'static, [lexer::TokenValue<'static>]>>,
@@ -16,14 +15,14 @@ pub struct Error<'a> {
 
 impl<'a> Error<'a> {
   pub fn new(
-    operation_kind: operation::OperationKind,
+    operation_keyword: &'static str,
     operation_token: lexer::Token<'a>,
     unexpected_token: Option<lexer::Token<'a>>,
     expected_tokens: Option<Cow<'static, [lexer::TokenValue<'static>]>>,
     details: Option<Cow<'static, str>>,
   ) -> Self {
     Error {
-      operation_kind,
+      operation_keyword,
       operation_token,
       unexpected_token,
       expected_tokens,
@@ -90,7 +89,7 @@ impl fmt::Display for Error<'_> {
     write!(
       f,
       "Error on {} operation on line {}, column {}:\n  {}\n  {}{}{}{}{}",
-      self.operation_kind,
+      self.operation_keyword,
       un_token.line_number,
       un_token.column_number,
       op_token.line.trim_end(),


### PR DESCRIPTION
- Format
- Refactor operation module
    - store modifiers as an enum instead of boolean flags
    - make Operation an enum, to force pattern-matching over it to retrieve the inner operation
    - extract each operation kind into separate struct
    - pass only keyword string to error generator
    - create keyword associated function for each operation type
    - modify all code affected by the changes
