### PR TITLE
Fix and refactor parser

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -14,10 +14,7 @@ pub fn string_length(word: &str) -> usize {
 }
 
 pub fn fmt_token_pointer(token_value: &str, col: usize) -> (String, String) {
-  (
-    " ".repeat(col - 1),
-    "^".repeat(string_length(token_value)),
-  )
+  (" ".repeat(col - 1), "^".repeat(string_length(token_value)))
 }
 
 pub fn fmt_list<'a, T: std::fmt::Display>(elems: &'a [T], sep: &str, linker: &str) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,6 @@
 use unic_ucd_category::GeneralCategory;
 use unicode_segmentation::UnicodeSegmentation;
 
-pub fn repeat_chars(ch: &str, n: usize) -> String {
-  std::iter::repeat(ch).take(n).collect()
-}
-
 pub fn is_alphabetic(s: &str) -> bool {
   s.chars().map(GeneralCategory::of).all(|c| c.is_letter())
 }
@@ -19,8 +15,8 @@ pub fn string_length(word: &str) -> usize {
 
 pub fn fmt_token_pointer(token_value: &str, col: usize) -> (String, String) {
   (
-    repeat_chars(" ", col - 1),
-    repeat_chars("^", string_length(token_value)),
+    " ".repeat(col - 1),
+    "^".repeat(string_length(token_value)),
   )
 }
 


### PR DESCRIPTION
- Replace function `repeat_chars` with str method repeat.
- Fix list parser, make errors and code more descriptive
    - lists are parsed correctly: ", and" now works, "and"s are no more parsed and multiple consecutive list separators are always treated as errors
    - use structs instead of tuples for errors, so values have descriptive names and the error handling is easier to understand
    - tweak error messages to better describe the problem
    - modify tests
- Format files
